### PR TITLE
added except subprocess.CalledProcessError to catch task errors

### DIFF
--- a/rebootmgr/main.py
+++ b/rebootmgr/main.py
@@ -292,6 +292,10 @@ def cli(verbose, consul, consul_port, check_triggers, check_uptime, dryrun, main
                 LOG.info("Global stop flag is set: exit")
                 sys.exit(EXIT_GLOBAL_STOP_FLAG_SET)
 
+            # check again if reboot is still required
+            if check_triggers and not is_reboot_required(con, hostname):
+                sys.exit(0)
+
             if not dryrun:
                 LOG.debug("Write %s in key service/rebootmgr/reboot_in_progress" % hostname)
                 con.kv.put("service/rebootmgr/reboot_in_progress", hostname)

--- a/rebootmgr/main.py
+++ b/rebootmgr/main.py
@@ -69,6 +69,9 @@ def run_tasks(tasktype, con, hostname, dryrun):
         LOG.info("Run task %s" % task)
         try:
             subprocess.run(task, check=True, env=env, timeout=(2 * 60 * 60))
+        except subprocess.CalledProcessError as e:
+            LOG.error("Task %s failed with return code %s. Exit" % (task,e.returncode))
+            sys.exit(EXIT_TASK_FAILED)
         except subprocess.TimeoutExpired:
             LOG.error("Could not finish task %s in 2 hours. Exit" % task)
             LOG.error("Disable rebootmgr in consul for this node")


### PR DESCRIPTION
added except subprocess.CalledProcessError in run_tasks to catch task errors and print a corresponding message. 