### PR TITLE
Demand that configuration data is present.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,16 @@ services:
     depends_on: [consul1, consul2, consul3, consul4]
     command:
       ["tox", "-e", "py37"]
+  lint:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        PYTHON_VERSION: 3.5
+    volumes:
+      - .:/src
+    command:
+      ["tox", "-e", "lint"]
   consul1:
     image: consul:1.3.0
     ports:

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,3 +3,7 @@
 At SysEleven, we are using debian packages to install rebootmgr.
 
 As soon as we publish the first release on GitHub, we will add a public Launchpad Repository with a getting-started guide here.
+
+On all nodes to be managed with rebootmgr, run `rebootmgr --ensure-config`,
+to ensure that default configuration for the node is present in the
+consul key/value store (if not present yet).

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -11,7 +11,7 @@ On a very high level, the functionality can be summarized with the following bul
 
 ## Configuration options
 
-You can configure rebootmgr in your cluster using the consul kv store.
+You can configure rebootmgr in your cluster using the consul key/value (kv) store.
 
 ### Global stop flag (`service/rebootmgr/stop`)
 
@@ -37,15 +37,24 @@ $ consul kv put service/rebootmgr/ignore_failed_checks '["some_hostname"]'
 
 ### Host-specific configuration (`service/rebootmgr/nodes/{hostname}/config`)
 
-Reboot Manager will be enabled on all hosts by default.
+You can enable or disable Reboot Manager on individual hosts using this key.
 
-You can disable reboot manager on certain hosts using this key.
+Reboot Manager will allow reboots only if this configuration is present and
+well-formed, so by default, Reboot Manager will be disabled[^1].
+
+To ensure that the configuration is present:
+```
+some_hostname$ rebootmgr --ensure-config
+```
+If the configuration is absent or invalid, it will create it, allowing reboots.
 
 Example for disabling reboot manager on `some_hostname`:
+```
+$ consul kv put service/rebootmgr/nodes/some_hostname/config '{"disabled": true}'
+```
 
-```
-$ consul kv put service/rebootmgr/nodes/some_hostname/config '{"enabled": False}'
-```
+[^1]: This is the reverse of earlier versions. We decided for safety reasons to
+allow reboots only when the configuration is properly present.
 
 ## Consul service monitoring
 

--- a/rebootmgr/main.py
+++ b/rebootmgr/main.py
@@ -1,5 +1,6 @@
 import os
 import click
+import getpass
 import logging
 import socket
 import sys
@@ -313,15 +314,20 @@ def ensure_configuration(con, hostname, dryrun) -> bool:
     return False
 
 
+def getuser():
+    user = os.environ.get('SUDO_USER')
+    return user or getpass.getuser()
+
+
 def do_set_global_stop_flag(con, dc):
-    reason = "Set by " + os.environ.get("LOGNAME", "(unknown)")\
+    reason = "Set by " + getuser()\
              + " " + str(datetime.datetime.now())
     con.kv.put("service/rebootmgr/stop", reason, dc=dc)
     LOG.warning("Set %s global stop flag: %s", dc, reason)
 
 
 def do_set_local_stop_flag(con, hostname):
-    reason = "Node disabled by " + os.environ.get("LOGNAME", "(unknown)")\
+    reason = "Node disabled by " + getuser()\
              + " " + str(datetime.datetime.now())
     config = get_config(con, hostname)
     config["disabled"] = True

--- a/rebootmgr/main.py
+++ b/rebootmgr/main.py
@@ -216,7 +216,7 @@ def pre_reboot_state(con, consul_lock, hostname, flags):
         LOG.info("Global stop flag is set: exit")
         sys.exit(EXIT_GLOBAL_STOP_FLAG_SET)
 
-    if is_node_disabled(con, hostname) and not flags.get("ignore_global_stop_flag"):
+    if is_node_disabled(con, hostname) and not flags.get("ignore_node_disabled"):
         LOG.info("Rebootmgr is disabled in consul config for this node. Exit")
         sys.exit(EXIT_NODE_DISABLED)
 

--- a/rebootmgr/main.py
+++ b/rebootmgr/main.py
@@ -9,7 +9,7 @@ import time
 import colorlog
 import holidays
 import datetime
-from typing import List, Optional
+from typing import List
 
 from retrying import retry
 from consul import Consul
@@ -80,7 +80,7 @@ def run_tasks(tasktype, con, hostname, dryrun):
             data = get_config(con, hostname)
             data["disabled"] = True
             data["message"] = "Could not finish task %s in 2 hours" % task
-            put_config(con, hostname)
+            put_config(con, hostname, data)
             con.kv.delete("service/rebootmgr/reboot_in_progress")
             sys.exit(EXIT_TASK_FAILED)
         LOG.info("task %s finished" % task)
@@ -271,7 +271,7 @@ def get_config(con, hostname) -> dict:
             data = json.loads(data["Value"].decode())
             if isinstance(data, dict):
                 return data
-    except:
+    except Exception:
         pass
 
     LOG.error("Configuration data missing or malformed.")

--- a/rebootmgr/main.py
+++ b/rebootmgr/main.py
@@ -410,4 +410,4 @@ def cli(verbose, consul, consul_port, check_triggers, check_uptime, dryrun, main
 
 
 if __name__ == "__main__":
-    cli()
+    cli()  # pragma: no cover

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import time
 import json
 import logging
 import requests
+import socket
 import subprocess
 
 from unittest.mock import DEFAULT
@@ -121,6 +122,13 @@ def reboot_task(mocker, mock_subprocess_run):
             side_effect)
 
     return create_task
+
+
+@pytest.fixture
+def default_config(consul_cluster):
+    hostname = socket.gethostname()
+    key = "service/rebootmgr/nodes/%s/config" % hostname
+    consul_cluster[0].kv.put(key, '{"disabled": false}')
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,8 @@ def consul_cluster():
         resp.raise_for_status()
         for c in clients:
             c.agent.maintenance(False)
+            for name, service in c.agent.services().items():
+                c.agent.service.deregister(name)
 
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,32 @@
+from rebootmgr.main import cli as rebootmgr
+
+import json
+import pytest
+import socket
+
+
+def test_ensure_config_when_already_valid(run_cli, forward_consul_port, default_config):
+    result = run_cli(rebootmgr, ["-vv", "--ensure-config"])
+
+    assert "Did not create default configuration, since there already was one." in result.output
+    assert result.exit_code == 0
+
+@pytest.mark.parametrize("bad_config",
+                         ['', '{}', 'disabled', '{"enabled": true}'])
+def test_ensure_config_when_invalid(run_cli, forward_consul_port,
+                                    consul_cluster, bad_config):
+    hostname = socket.gethostname()
+    consul_cluster[0].kv.put("service/rebootmgr/nodes/%s/config" % hostname, bad_config)
+
+    result = run_cli(rebootmgr, ["-v", "--ensure-config"])
+
+    assert "Created default configuration, since it was missing or invalid." in result.output
+
+    _, data = consul_cluster[0].kv.get("service/rebootmgr/nodes/{}/config".format(
+        hostname))
+    assert json.loads(data["Value"].decode()) == {
+        "disabled": False,
+        "message": "Default config created"
+    }
+
+    assert result.exit_code == 0

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,0 +1,13 @@
+from rebootmgr.main import cli as rebootmgr
+from consul_lib import Lock
+
+
+def test_consul_lock_fails(
+        run_cli, forward_consul_port, consul_cluster, default_config):
+    with Lock(consul_cluster[0], "service/rebootmgr/lock"):
+        result = run_cli(rebootmgr, ["-v"], catch_exceptions=True)
+
+        assert "Could not get consul lock. Exit" in result.output
+        assert result.exit_code == 4
+
+# TODO(oseibert): Test when the lock is lost during the 2 minute sleep.

--- a/tests/test_reboot.py
+++ b/tests/test_reboot.py
@@ -1,7 +1,7 @@
 import socket
 
 from rebootmgr.main import cli as rebootmgr
-
+from unittest.mock import mock_open
 
 def test_reboot_fails_without_config(run_cli, forward_consul_port):
     result = run_cli(rebootmgr, ["-v"], catch_exceptions=True)
@@ -19,7 +19,9 @@ def test_reboot_fails_without_tasks(run_cli, forward_consul_port, default_config
     assert isinstance(result.exception, FileNotFoundError)
 
 
-def test_reboot_success_with_tasks(run_cli, forward_consul_port, default_config, reboot_task, mock_subprocess_run, mocker):
+def test_reboot_success_with_tasks(run_cli, forward_consul_port, consul_cluster,
+                                   default_config, reboot_task,
+                                   mock_subprocess_run, mocker):
     mocked_sleep = mocker.patch("time.sleep")
     reboot_task("pre_boot", "00_some_task.sh")
     mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
@@ -34,6 +36,41 @@ def test_reboot_success_with_tasks(run_cli, forward_consul_port, default_config,
     # We want rebootmgr to sleep for 2 minutes after running the pre boot tasks,
     # so that we can notice when the tasks broke some consul checks.
     mocked_sleep.assert_any_call(130)
+
+    # Check that it sets the reboot_in_progress flag
+    _, data = consul_cluster[0].kv.get("service/rebootmgr/reboot_in_progress")
+    assert data["Value"].decode() == socket.gethostname()
+
+
+def test_dryrun_reboot_success_with_tasks(run_cli, forward_consul_port,
+                                          consul_cluster, default_config,
+                                          reboot_task, mock_subprocess_run,
+                                          mocker):
+    mocked_sleep = mocker.patch("time.sleep")
+    reboot_task("pre_boot", "00_some_task.sh")
+    mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
+
+    result = run_cli(rebootmgr, ["-vv", "--dryrun"])
+
+    assert "00_some_task.sh" in result.output
+    assert "in key service/rebootmgr/reboot_in_progress" in result.output
+    assert result.exit_code == 0
+
+    mocked_run.assert_called_once()
+    args, kwargs = mocked_run.call_args
+    assert args[0] == "/etc/rebootmgr/pre_boot_tasks/00_some_task.sh"
+    assert 'env' in kwargs
+    assert 'REBOOTMGR_DRY_RUN' in kwargs['env']
+    assert kwargs['env']['REBOOTMGR_DRY_RUN'] == "1"
+    # In particular, 'shutdown' is not called
+
+    # We want rebootmgr to sleep for 2 minutes after running the pre boot tasks,
+    # so that we can notice when the tasks broke some consul checks.
+    mocked_sleep.assert_any_call(130)
+
+    # Check that it does not set the reboot_in_progress flag
+    _, data = consul_cluster[0].kv.get("service/rebootmgr/reboot_in_progress")
+    assert not data
 
 
 def test_reboot_fail(run_cli, forward_consul_port, default_config, reboot_task, mock_subprocess_run, mocker):
@@ -82,3 +119,16 @@ def test_post_reboot_phase_success_with_tasks(run_cli, forward_consul_port, defa
 
     assert result.exit_code == 0
     assert "50_another_task.sh" in result.output
+
+def test_post_reboot_phase_failure_with_uptime(run_cli, forward_consul_port,
+                                               default_config, consul_cluster,
+                                               reboot_task, mocker):
+    mocked_open = mocker.patch('__main__.open', new=mock_open(read_data='99999999.9 99999999.9'))
+    reboot_task("post_boot", "50_another_task.sh")
+
+    consul_cluster[0].kv.put("service/rebootmgr/reboot_in_progress", socket.gethostname())
+
+    result = run_cli(rebootmgr, ["-v", "--check-uptime"])
+
+    assert "We are in post reboot state but uptime is higher then 2 hours." in result.output
+    assert result.exit_code == 103

--- a/tests/test_stopflag.py
+++ b/tests/test_stopflag.py
@@ -1,7 +1,7 @@
 from rebootmgr.main import cli as rebootmgr
 
 
-def test_not_verbose(run_cli, forward_consul_port, consul_cluster):
+def test_not_verbose(run_cli, consul_cluster, forward_consul_port, default_config):
     consul_cluster[0].kv.put("service/rebootmgr/stop", "reason: stopped for testing")
 
     result = run_cli(rebootmgr)
@@ -13,7 +13,7 @@ def test_not_verbose(run_cli, forward_consul_port, consul_cluster):
     assert not result.output
 
 
-def test_verbose(run_cli, forward_consul_port, consul_cluster):
+def test_verbose(run_cli, consul_cluster, forward_consul_port, default_config):
     consul_cluster[0].kv.put("service/rebootmgr/stop", "reason: stopped for testing")
 
     result1 = run_cli(rebootmgr, ["-v"])

--- a/tests/test_stopflag.py
+++ b/tests/test_stopflag.py
@@ -1,3 +1,6 @@
+import json
+import socket
+
 from rebootmgr.main import cli as rebootmgr
 
 
@@ -23,3 +26,41 @@ def test_verbose(run_cli, consul_cluster, forward_consul_port, default_config):
     result2 = run_cli(rebootmgr, ["-vv"])
     assert "Global stop flag is set" in result2.output
     assert "service/rebootmgr/stop" in result2.output
+
+
+def test_set_global_stop_flag(
+        run_cli, forward_consul_port, consul_cluster,
+        mock_subprocess_run, mocker):
+    mocked_sleep = mocker.patch("time.sleep")
+    mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
+    datacenter = "test"
+
+    result = run_cli(rebootmgr, ["-v", "--set-global-stop-flag", datacenter])
+
+    mocked_sleep.assert_not_called()
+    mocked_run.assert_not_called()
+    assert "Set "+datacenter+" global stop flag:" in result.output
+    idx, data = consul_cluster[0].kv.get("service/rebootmgr/stop", dc=datacenter)
+    assert idx is not None
+    assert data != ""
+    assert result.exit_code == 0
+
+
+def test_set_local_stop_flag(
+        run_cli, forward_consul_port, consul_cluster,
+        mock_subprocess_run, mocker):
+    mocked_sleep = mocker.patch("time.sleep")
+    mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
+    hostname = socket.gethostname().split(".")[0]
+
+    result = run_cli(rebootmgr, ["-v", "--set-local-stop-flag"])
+
+    mocked_sleep.assert_not_called()
+    mocked_run.assert_not_called()
+    assert "Set "+hostname+" local stop flag:" in result.output
+    idx, data = consul_cluster[0].kv.get("service/rebootmgr/nodes/{}/config".format(
+        hostname))
+    assert idx is not None
+    config = json.loads(data["Value"].decode())
+    assert config['disabled'] is True
+    assert result.exit_code == 0

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,12 +1,9 @@
 import json
 import socket
 
-import pytest
-
 from rebootmgr.main import cli as rebootmgr
 
 
-@pytest.mark.xfail  # TODO(sneubauer): Fix bug in rebootmgr
 def test_reboot_task_timeout(run_cli, consul_cluster, forward_consul_port, default_config, reboot_task, mocker):
     mocker.patch("time.sleep")
     reboot_task("pre_boot", "00_some_task.sh", raise_timeout_expired=True)
@@ -18,9 +15,26 @@ def test_reboot_task_timeout(run_cli, consul_cluster, forward_consul_port, defau
 
     _, data = consul_cluster[0].kv.get("service/rebootmgr/nodes/{}/config".format(socket.gethostname()))
     assert json.loads(data["Value"].decode()) == {
-        "enabled": False,
+        "disabled": True,
         "message": "Could not finish task /etc/rebootmgr/pre_boot_tasks/00_some_task.sh in 2 hours"
     }
+    # TODO(oseibert): check that shutdown is NOT called.
+
+
+def test_reboot_preboot_task_fails(run_cli, consul_cluster, forward_consul_port, default_config, reboot_task, mocker):
+    mocker.patch("time.sleep")
+    reboot_task("pre_boot", "00_some_task.sh", exit_code=1)
+
+    result = run_cli(rebootmgr)
+
+    assert "Task /etc/rebootmgr/pre_boot_tasks/00_some_task.sh failed with return code 1" in result.output
+    assert result.exit_code == 100
+
+    _, data = consul_cluster[0].kv.get("service/rebootmgr/nodes/{}/config".format(socket.gethostname()))
+    assert json.loads(data["Value"].decode()) == {
+        "disabled": False,
+    }
+    # TODO(oseibert): check that shutdown is NOT called.
 
 
 def test_reboot_task_timeout_with_preexisting_config(run_cli, consul_cluster, forward_consul_port, reboot_task, mocker):
@@ -39,9 +53,9 @@ def test_reboot_task_timeout_with_preexisting_config(run_cli, consul_cluster, fo
         "disabled": True,
         "message": "Could not finish task /etc/rebootmgr/pre_boot_tasks/00_some_task.sh in 2 hours"
     }
+    # TODO(oseibert): check that shutdown is NOT called.
 
 
-@pytest.mark.xfail  # TODO(sneubauer): Fix bug in rebootmgr
 def test_post_reboot_phase_task_timeout(run_cli, consul_cluster, forward_consul_port, default_config, reboot_task, mocker):
     reboot_task("post_boot", "50_another_task.sh", raise_timeout_expired=True)
 
@@ -50,11 +64,11 @@ def test_post_reboot_phase_task_timeout(run_cli, consul_cluster, forward_consul_
 
     result = run_cli(rebootmgr)
 
-    assert "Could not finish task /etc/rebootmgr/pre_boot_tasks/50_another_task.sh in 2 hours" in result.output
+    assert "Could not finish task /etc/rebootmgr/post_boot_tasks/50_another_task.sh in 2 hours" in result.output
     assert result.exit_code == 100
 
     _, data = consul_cluster[0].kv.get("service/rebootmgr/nodes/{}/config".format(socket.gethostname()))
     assert json.loads(data["Value"].decode()) == {
-        "enabled": False,
-        "message": "Could not finish task /etc/rebootmgr/pre_boot_tasks/00_some_task.sh in 2 hours"
+        "disabled": True,
+        "message": "Could not finish task /etc/rebootmgr/post_boot_tasks/50_another_task.sh in 2 hours"
     }

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -145,12 +145,14 @@ def test_reboot_when_node_disabled_but_ignored(
     mocked_sleep = mocker.patch("time.sleep")
     mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
 
-    result = run_cli(rebootmgr, ["-v", "--ignore-global-stop-flag"])
+    result = run_cli(rebootmgr, ["-v", "--ignore-node-disabled"])
 
     mocked_sleep.assert_any_call(130)
     mocked_run.assert_any_call(["shutdown", "-r", "+1"], check=True)
     assert "Reboot now ..." in result.output
     assert result.exit_code == 0
+
+# TODO(oseibert): Should a MISSING configuration also be ignored with --ignore-node-disabled?
 
 # TODO(oseibert): Fix this bug.
 @pytest.mark.xfail

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -1,7 +1,7 @@
 from rebootmgr.main import cli as rebootmgr
 
 
-def test_reboot_not_required(run_cli, forward_consul_port, reboot_task):
+def test_reboot_not_required(run_cli, forward_consul_port, default_config, reboot_task):
     result = run_cli(rebootmgr, ["-v", "--check-triggers"])
 
     assert "No reboot necessary" in result.output

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -171,7 +171,6 @@ def test_reboot_when_node_disabled_after_sleep(
 
     mocked_sleep.assert_any_call(130)
     mocked_run.assert_not_called()
-    assert "Reboot now ..." in result.output
     assert result.exit_code == 101
 
 

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -1,8 +1,131 @@
 from rebootmgr.main import cli as rebootmgr
 
+import datetime
+import socket
 
 def test_reboot_not_required(run_cli, forward_consul_port, default_config, reboot_task):
     result = run_cli(rebootmgr, ["-v", "--check-triggers"])
 
     assert "No reboot necessary" in result.output
+    assert result.exit_code == 0
+
+
+def test_reboot_required_because_consul(run_cli, forward_consul_port,
+                                        consul_cluster, default_config,
+                                        reboot_task, mock_subprocess_run, mocker):
+    consul_cluster[0].kv.put("service/rebootmgr/nodes/%s/reboot_required" % socket.gethostname(), "")
+
+    mocked_sleep = mocker.patch("time.sleep")
+    mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
+
+    result = run_cli(rebootmgr, ["-v", "--check-triggers"])
+
+    mocked_sleep.assert_any_call(130)
+    mocked_run.assert_any_call(["shutdown", "-r", "+1"], check=True)
+    assert "Reboot now ..." in result.output
+    assert result.exit_code == 0
+
+
+def test_reboot_required_because_file(run_cli, forward_consul_port,
+                                      default_config,
+                                      reboot_task, mock_subprocess_run, mocker):
+    mocked_sleep = mocker.patch("time.sleep")
+    mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
+    mocker.patch("os.path.isfile", new=lambda f: f == "/var/run/reboot-required")
+
+    result = run_cli(rebootmgr, ["-v", "--check-triggers"])
+
+    mocked_sleep.assert_any_call(130)
+    mocked_run.assert_any_call(["shutdown", "-r", "+1"], check=True)
+    assert "Reboot now ..." in result.output
+    assert result.exit_code == 0
+
+
+def test_reboot_on_holiday(run_cli, forward_consul_port,
+                                      default_config,
+                                      reboot_task, mock_subprocess_run, mocker):
+    mocked_sleep = mocker.patch("time.sleep")
+    mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
+
+    today = datetime.date.today()
+    mocker.patch("holidays.DE", new=lambda: [today])
+
+    result = run_cli(rebootmgr, ["-v", "--check-holidays"])
+
+    assert result.exit_code == 6
+
+
+def test_reboot_on_not_a_holiday(run_cli, forward_consul_port,
+                                      default_config,
+                                      reboot_task, mock_subprocess_run, mocker):
+    mocked_sleep = mocker.patch("time.sleep")
+    mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
+
+    mocker.patch("holidays.DE", new=lambda: [])
+
+    result = run_cli(rebootmgr, ["-v", "--check-holidays"])
+
+    mocked_sleep.assert_any_call(130)
+    mocked_run.assert_any_call(["shutdown", "-r", "+1"], check=True)
+    assert "Reboot now ..." in result.output
+    assert result.exit_code == 0
+
+
+def test_reboot_when_node_disabled(run_cli, forward_consul_port,
+                                   consul_cluster,
+                                   reboot_task, mock_subprocess_run, mocker):
+    consul_cluster[0].kv.put("service/rebootmgr/nodes/{}/config".format(socket.gethostname()), '{"disabled": true}')
+
+    mocker.patch("time.sleep")
+    mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
+
+    result = run_cli(rebootmgr, ["-v"])
+
+    mocked_run.assert_not_called()
+    assert result.exit_code == 101
+
+
+def test_reboot_when_node_disabled_but_ignored(run_cli, forward_consul_port,
+                                   consul_cluster,
+                                   reboot_task, mock_subprocess_run, mocker):
+    consul_cluster[0].kv.put("service/rebootmgr/nodes/{}/config".format(socket.gethostname()), '{"disabled": true}')
+
+    mocked_sleep = mocker.patch("time.sleep")
+    mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
+
+    result = run_cli(rebootmgr, ["-v", "--ignore-global-stop-flag"])
+
+    mocked_sleep.assert_any_call(130)
+    mocked_run.assert_any_call(["shutdown", "-r", "+1"], check=True)
+    assert "Reboot now ..." in result.output
+    assert result.exit_code == 0
+
+
+def test_reboot_when_global_stop_flag(run_cli, forward_consul_port,
+                                   consul_cluster, default_config,
+                                   reboot_task, mock_subprocess_run, mocker):
+    consul_cluster[0].kv.put("service/rebootmgr/stop", "")
+
+    mocker.patch("time.sleep")
+    mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
+
+    result = run_cli(rebootmgr, ["-v"])
+
+    mocked_run.assert_not_called()
+    assert result.exit_code == 102
+
+
+def test_reboot_when_global_stop_flag_when_ignored(run_cli, forward_consul_port,
+                                   consul_cluster, default_config,
+                                   reboot_task, mock_subprocess_run, mocker):
+    consul_cluster[0].kv.put("service/rebootmgr/stop", "")
+
+    mocked_sleep = mocker.patch("time.sleep")
+    mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
+
+    result = run_cli(rebootmgr, ["-v", "--ignore-global-stop-flag"])
+
+    mocked_sleep.assert_any_call(130)
+    mocked_run.assert_any_call(["shutdown", "-r", "+1"], check=True)
+    assert "Reboot now ..." in result.output
     assert result.exit_code == 0

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -3,6 +3,7 @@ from rebootmgr.main import cli as rebootmgr
 import datetime
 import socket
 
+
 def test_reboot_not_required(run_cli, forward_consul_port, default_config, reboot_task):
     result = run_cli(rebootmgr, ["-v", "--check-triggers"])
 
@@ -10,9 +11,9 @@ def test_reboot_not_required(run_cli, forward_consul_port, default_config, reboo
     assert result.exit_code == 0
 
 
-def test_reboot_required_because_consul(run_cli, forward_consul_port,
-                                        consul_cluster, default_config,
-                                        reboot_task, mock_subprocess_run, mocker):
+def test_reboot_required_because_consul(
+        run_cli, forward_consul_port, consul_cluster, default_config,
+        reboot_task, mock_subprocess_run, mocker):
     consul_cluster[0].kv.put("service/rebootmgr/nodes/%s/reboot_required" % socket.gethostname(), "")
 
     mocked_sleep = mocker.patch("time.sleep")
@@ -26,9 +27,9 @@ def test_reboot_required_because_consul(run_cli, forward_consul_port,
     assert result.exit_code == 0
 
 
-def test_reboot_required_because_file(run_cli, forward_consul_port,
-                                      default_config,
-                                      reboot_task, mock_subprocess_run, mocker):
+def test_reboot_required_because_file(
+        run_cli, forward_consul_port, default_config, reboot_task,
+        mock_subprocess_run, mocker):
     mocked_sleep = mocker.patch("time.sleep")
     mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
     mocker.patch("os.path.isfile", new=lambda f: f == "/var/run/reboot-required")
@@ -41,23 +42,25 @@ def test_reboot_required_because_file(run_cli, forward_consul_port,
     assert result.exit_code == 0
 
 
-def test_reboot_on_holiday(run_cli, forward_consul_port,
-                                      default_config,
-                                      reboot_task, mock_subprocess_run, mocker):
-    mocked_sleep = mocker.patch("time.sleep")
+def test_reboot_on_holiday(
+        run_cli, forward_consul_port, default_config, reboot_task,
+        mock_subprocess_run, mocker):
+    mocker.patch("time.sleep")
     mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
 
     today = datetime.date.today()
-    mocker.patch("holidays.DE", new=lambda: [today])
+    tomorrow = today + datetime.timedelta(days=1)
+    mocker.patch("holidays.DE", new=lambda: [today, tomorrow])
 
     result = run_cli(rebootmgr, ["-v", "--check-holidays"])
 
+    mocked_run.assert_not_called()
     assert result.exit_code == 6
 
 
-def test_reboot_on_not_a_holiday(run_cli, forward_consul_port,
-                                      default_config,
-                                      reboot_task, mock_subprocess_run, mocker):
+def test_reboot_on_not_a_holiday(
+        run_cli, forward_consul_port, default_config, reboot_task,
+        mock_subprocess_run, mocker):
     mocked_sleep = mocker.patch("time.sleep")
     mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
 
@@ -71,9 +74,9 @@ def test_reboot_on_not_a_holiday(run_cli, forward_consul_port,
     assert result.exit_code == 0
 
 
-def test_reboot_when_node_disabled(run_cli, forward_consul_port,
-                                   consul_cluster,
-                                   reboot_task, mock_subprocess_run, mocker):
+def test_reboot_when_node_disabled(
+        run_cli, forward_consul_port, consul_cluster, reboot_task,
+        mock_subprocess_run, mocker):
     consul_cluster[0].kv.put("service/rebootmgr/nodes/{}/config".format(socket.gethostname()), '{"disabled": true}')
 
     mocker.patch("time.sleep")
@@ -85,9 +88,9 @@ def test_reboot_when_node_disabled(run_cli, forward_consul_port,
     assert result.exit_code == 101
 
 
-def test_reboot_when_node_disabled_but_ignored(run_cli, forward_consul_port,
-                                   consul_cluster,
-                                   reboot_task, mock_subprocess_run, mocker):
+def test_reboot_when_node_disabled_but_ignored(
+        run_cli, forward_consul_port, consul_cluster, reboot_task,
+        mock_subprocess_run, mocker):
     consul_cluster[0].kv.put("service/rebootmgr/nodes/{}/config".format(socket.gethostname()), '{"disabled": true}')
 
     mocked_sleep = mocker.patch("time.sleep")
@@ -101,9 +104,9 @@ def test_reboot_when_node_disabled_but_ignored(run_cli, forward_consul_port,
     assert result.exit_code == 0
 
 
-def test_reboot_when_global_stop_flag(run_cli, forward_consul_port,
-                                   consul_cluster, default_config,
-                                   reboot_task, mock_subprocess_run, mocker):
+def test_reboot_when_global_stop_flag(
+        run_cli, forward_consul_port, consul_cluster, default_config,
+        reboot_task, mock_subprocess_run, mocker):
     consul_cluster[0].kv.put("service/rebootmgr/stop", "")
 
     mocker.patch("time.sleep")
@@ -115,9 +118,9 @@ def test_reboot_when_global_stop_flag(run_cli, forward_consul_port,
     assert result.exit_code == 102
 
 
-def test_reboot_when_global_stop_flag_when_ignored(run_cli, forward_consul_port,
-                                   consul_cluster, default_config,
-                                   reboot_task, mock_subprocess_run, mocker):
+def test_reboot_when_global_stop_flag_when_ignored(
+        run_cli, forward_consul_port, consul_cluster, default_config,
+        reboot_task, mock_subprocess_run, mocker):
     consul_cluster[0].kv.put("service/rebootmgr/stop", "")
 
     mocked_sleep = mocker.patch("time.sleep")

--- a/tests/test_whitelist.py
+++ b/tests/test_whitelist.py
@@ -22,7 +22,7 @@ def test_reboot_succeeds_with_failed_checks_if_whitelisted(
     assert result.exit_code == 0
 
 
-def test_rebooting_fails_with_failing_checks(
+def test_reboot_fails_with_failing_checks(
         run_cli, consul_cluster, forward_consul_port, default_config,
         reboot_task, mock_subprocess_run, mocker):
     consul_cluster[0].agent.service.register("A", tags=["rebootmgr"])
@@ -38,7 +38,7 @@ def test_rebooting_fails_with_failing_checks(
     assert result.exit_code == 2
 
 
-def test_rebooting_fails_with_failing_consul_cluster(
+def test_reboot_fails_with_failing_consul_cluster(
         run_cli, forward_consul_port, default_config,
         reboot_task, mock_subprocess_run, mocker):
     # mocker.patch("time.sleep")
@@ -57,7 +57,7 @@ def test_rebooting_fails_with_failing_consul_cluster(
     assert result.exit_code == 3
 
 
-def test_rebooting_succeeds_with_failing_consul_cluster_if_whitelisted(
+def test_reboot_succeeds_with_failing_consul_cluster_if_whitelisted(
         run_cli, consul_cluster, forward_consul_port, default_config,
         reboot_task, mock_subprocess_run, mocker):
     consul_cluster[0].kv.put("service/rebootmgr/ignore_failed_checks", '["consul2"]')
@@ -75,3 +75,6 @@ def test_rebooting_succeeds_with_failing_consul_cluster_if_whitelisted(
     result = run_cli(rebootmgr, ["-v"])
 
     assert result.exit_code == 0
+
+# TODO(oseibert): Test cases where consul service checks succeed/fail after the
+#  (2 * 60) + 10 seconds sleeping time, when they are done the second time.

--- a/tests/test_whitelist.py
+++ b/tests/test_whitelist.py
@@ -10,7 +10,8 @@ def test_reboot_succeeds_with_failed_checks_if_whitelisted(
     consul_cluster[0].kv.put("service/rebootmgr/ignore_failed_checks", '["consul2"]')
 
     consul_cluster[0].agent.service.register("A", tags=["rebootmgr"])
-    consul_cluster[1].agent.service.register("A", tags=["rebootmgr"], check=Check.ttl("1ms"))  # Failing
+    consul_cluster[1].agent.service.register("A", tags=["rebootmgr"],
+                                             check=Check.ttl("1ms"))  # Failing
     time.sleep(0.01)
 
     mocker.patch("time.sleep")
@@ -25,7 +26,8 @@ def test_rebooting_fails_with_failing_checks(
         run_cli, consul_cluster, forward_consul_port, default_config,
         reboot_task, mock_subprocess_run, mocker):
     consul_cluster[0].agent.service.register("A", tags=["rebootmgr"])
-    consul_cluster[1].agent.service.register("A", tags=["rebootmgr"], check=Check.ttl("1ms"))  # Failing
+    consul_cluster[1].agent.service.register("A", tags=["rebootmgr"],
+                                             check=Check.ttl("1ms"))  # Failing
     time.sleep(0.01)
 
     mocker.patch("time.sleep")
@@ -34,3 +36,37 @@ def test_rebooting_fails_with_failing_checks(
     result = run_cli(rebootmgr, ["-v"])
 
     assert result.exit_code == 2
+
+def test_rebooting_fails_with_failing_consul_cluster(
+        run_cli, forward_consul_port, default_config,
+        reboot_task, mock_subprocess_run, mocker):
+    # mocker.patch("time.sleep")
+    mock_subprocess_run(["shutdown", "-r", "+1"])
+    def newmembers(self):
+        return [
+            {'Status': 1, 'Name': 'consul1'},
+            {'Status': 0, 'Name': 'consul2'},
+        ]
+    mocker.patch("consul.base.Consul.Agent.members", new=newmembers)
+
+    result = run_cli(rebootmgr, ["-v"])
+
+    assert result.exit_code == 3
+
+
+def test_rebooting_succeeds_with_failing_consul_cluster_if_whitelisted(
+        run_cli, consul_cluster, forward_consul_port, default_config,
+        reboot_task, mock_subprocess_run, mocker):
+    consul_cluster[0].kv.put("service/rebootmgr/ignore_failed_checks", '["consul2"]')
+    mocker.patch("time.sleep")
+    mock_subprocess_run(["shutdown", "-r", "+1"])
+    def newmembers(self):
+        return [
+            {'Status': 1, 'Name': 'consul1'},
+            {'Status': 0, 'Name': 'consul2'},
+        ]
+    mocker.patch("consul.base.Consul.Agent.members", new=newmembers)
+
+    result = run_cli(rebootmgr, ["-v"])
+
+    assert result.exit_code == 0

--- a/tests/test_whitelist.py
+++ b/tests/test_whitelist.py
@@ -4,7 +4,9 @@ from rebootmgr.main import cli as rebootmgr
 from consul import Check
 
 
-def test_reboot_succeeds_with_failed_checks_if_whitelisted(run_cli, forward_consul_port, consul_cluster, reboot_task, mock_subprocess_run, mocker):
+def test_reboot_succeeds_with_failed_checks_if_whitelisted(
+        run_cli, consul_cluster, forward_consul_port, default_config,
+        reboot_task, mock_subprocess_run, mocker):
     consul_cluster[0].kv.put("service/rebootmgr/ignore_failed_checks", '["consul2"]')
 
     consul_cluster[0].agent.service.register("A", tags=["rebootmgr"])
@@ -19,7 +21,9 @@ def test_reboot_succeeds_with_failed_checks_if_whitelisted(run_cli, forward_cons
     assert result.exit_code == 0
 
 
-def test_rebooting_fails_with_failing_checks(run_cli, forward_consul_port, consul_cluster, reboot_task, mock_subprocess_run, mocker):
+def test_rebooting_fails_with_failing_checks(
+        run_cli, consul_cluster, forward_consul_port, default_config,
+        reboot_task, mock_subprocess_run, mocker):
     consul_cluster[0].agent.service.register("A", tags=["rebootmgr"])
     consul_cluster[1].agent.service.register("A", tags=["rebootmgr"], check=Check.ttl("1ms"))  # Failing
     time.sleep(0.01)

--- a/tests/test_whitelist.py
+++ b/tests/test_whitelist.py
@@ -37,16 +37,19 @@ def test_rebooting_fails_with_failing_checks(
 
     assert result.exit_code == 2
 
+
 def test_rebooting_fails_with_failing_consul_cluster(
         run_cli, forward_consul_port, default_config,
         reboot_task, mock_subprocess_run, mocker):
     # mocker.patch("time.sleep")
     mock_subprocess_run(["shutdown", "-r", "+1"])
+
     def newmembers(self):
         return [
             {'Status': 1, 'Name': 'consul1'},
             {'Status': 0, 'Name': 'consul2'},
         ]
+
     mocker.patch("consul.base.Consul.Agent.members", new=newmembers)
 
     result = run_cli(rebootmgr, ["-v"])
@@ -60,11 +63,13 @@ def test_rebooting_succeeds_with_failing_consul_cluster_if_whitelisted(
     consul_cluster[0].kv.put("service/rebootmgr/ignore_failed_checks", '["consul2"]')
     mocker.patch("time.sleep")
     mock_subprocess_run(["shutdown", "-r", "+1"])
+
     def newmembers(self):
         return [
             {'Status': 1, 'Name': 'consul1'},
             {'Status': 0, 'Name': 'consul2'},
         ]
+
     mocker.patch("consul.base.Consul.Agent.members", new=newmembers)
 
     result = run_cli(rebootmgr, ["-v"])


### PR DESCRIPTION
Add an option to create a default config if missing.
Also add some type annotations to help PyCharm.