### PR TITLE
Oseibert os 5267 use enabled instead of disabled

### DIFF
--- a/rebootmgr/main.py
+++ b/rebootmgr/main.py
@@ -89,7 +89,7 @@ def run_tasks(tasktype, con, hostname, dryrun):
 
 def get_whitelist(con) -> List[str]:
     """
-    Reads a list of host which should be ignored. May be absent.
+    Reads a list of hosts which should be ignored. May be absent.
     """
     k, v = con.kv.get("service/rebootmgr/ignore_failed_checks")
     if v and "Value" in v.keys() and v["Value"]:
@@ -97,7 +97,7 @@ def get_whitelist(con) -> List[str]:
     return []
 
 
-def check_consul_services(con):
+def check_consul_services(con, ignore_failed_checks: bool):
     """
     check all consul services for this node with the tag "rebootmgr"
     """
@@ -110,14 +110,17 @@ def check_consul_services(con):
     local_checks = get_local_checks(con, tags=["rebootmgr"])
     LOG.debug("relevant_checks: %s" % local_checks)
 
-    for name, check in get_failed_cluster_checks(con, local_checks).items():
-        if check["Node"] in whitelist:
-            continue
+    if ignore_failed_checks:
+        LOG.warning("All consul service checks are ignored.")
+    else:
+        for name, check in get_failed_cluster_checks(con, local_checks).items():
+            if check["Node"] in whitelist:
+                continue
 
-        LOG.error("There were failed consul checks. Exit.")
-        sys.exit(EXIT_CONSUL_CHECKS_FAILED)
+            LOG.error("There were failed consul checks. Exit.")
+            sys.exit(EXIT_CONSUL_CHECKS_FAILED)
 
-    LOG.info("All consul checks passed.")
+        LOG.info("All consul checks passed.")
 
 
 @retry(wait_fixed=2000, stop_max_delay=20000)
@@ -166,15 +169,18 @@ def uptime() -> float:
         return uptime
 
 
-def check_consul_cluster(con) -> None:
+def check_consul_cluster(con, ignore_failed_checks: bool) -> None:
     whitelist = get_whitelist(con)
     if whitelist:
         LOG.warning("Status of the following hosts will be ignored, " +
                     "because service/rebootmgr/ignore_failed_checks is set: {}".format(", ".join(whitelist)))
-    for member in con.agent.members():
-        if "Status" in member.keys() and member["Status"] != 1 and member["Name"] not in whitelist:
-            LOG.error("Consul cluster not healthy: Node %s failed. Exit" % member["Name"])
-            sys.exit(EXIT_CONSUL_NODE_FAILED)
+    if ignore_failed_checks:
+        LOG.warning("All consul cluster checks are ignored.")
+    else:
+        for member in con.agent.members():
+            if "Status" in member.keys() and member["Status"] != 1 and member["Name"] not in whitelist:
+                LOG.error("Consul cluster not healthy: Node %s failed. Exit" % member["Name"])
+                sys.exit(EXIT_CONSUL_NODE_FAILED)
 
 
 @retry(wait_fixed=2000, stop_max_delay=20000)
@@ -195,9 +201,9 @@ def post_reboot_state(con, consul_lock, hostname, flags):
     # Disable consul (and Zabbix) maintenance
     con.agent.maintenance(False)
 
-    check_consul_services(con)
+    check_consul_services(con, flags.get("ignore_failed_checks"))
     run_tasks("post_boot", con, hostname, flags.get("dryrun"))
-    check_consul_services(con)
+    check_consul_services(con, flags.get("ignore_failed_checks"))
 
     LOG.info("Remove consul key service/rebootmgr/nodes/%s/reboot_required" % hostname)
     con.kv.delete("service/rebootmgr/nodes/%s/reboot_required" % hostname)
@@ -226,7 +232,7 @@ def pre_reboot_state(con, consul_lock, hostname, flags):
 
     LOG.info("Entering pre reboot state")
 
-    check_consul_services(con)
+    check_consul_services(con, flags.get("ignore_failed_checks"))
 
     LOG.info("Executing pre reboot tasks")
     run_tasks("pre_boot", con, hostname, flags.get("dryrun"))
@@ -235,8 +241,8 @@ def pre_reboot_state(con, consul_lock, hostname, flags):
         LOG.info("Sleep for 2 minutes. Waiting for consul checks.")
         time.sleep((60 * 2) + 10)
 
-    check_consul_cluster(con)
-    check_consul_services(con)
+    check_consul_cluster(con, flags.get("ignore_failed_checks"))
+    check_consul_services(con, flags.get("ignore_failed_checks"))
 
     if not consul_lock.acquired:
         LOG.error("Lost consul lock. Exit")
@@ -353,6 +359,7 @@ def do_set_local_stop_flag(con, hostname):
 @click.option("--check-holidays", help="Don't reboot on holidays", is_flag=True)
 @click.option("--lazy-consul-checks", help="Don't repeat consul checks after two minutes", is_flag=True)
 @click.option("-l", "--ignore-node-disabled", help="ignore the node specific stop flag (service/rebootmgr/hostname/config)", is_flag=True)
+@click.option("--ignore-failed-checks", help="Reboot even if consul checks fail", is_flag=True)
 @click.option("--maintenance-reason", help="""Reason for the downtime in consul. If the text starts with "reboot", """ +
               "a 15 minute maintenance period is scheduled in zabbix\nDefault: reboot by rebootmgr",
               default="reboot by rebootmgr")
@@ -365,7 +372,7 @@ def do_set_local_stop_flag(con, hostname):
 @click.option("--set-local-stop-flag", help="Stop the rebootmgr on this node", is_flag=True)
 @click.version_option()
 def cli(verbose, consul, consul_port, check_triggers, check_uptime, dryrun, maintenance_reason, ignore_global_stop_flag,
-        ignore_node_disabled, check_holidays, lazy_consul_checks, ensure_config,
+        ignore_node_disabled, ignore_failed_checks, check_holidays, lazy_consul_checks, ensure_config,
         set_global_stop_flag, set_local_stop_flag):
     """Reboot Manager
 
@@ -398,16 +405,17 @@ def cli(verbose, consul, consul_port, check_triggers, check_uptime, dryrun, main
                   "Exit." % hostname)
         sys.exit(EXIT_CONFIGURATION_IS_MISSING)
 
-    check_consul_cluster(con)
-
     flags = {"check_triggers": check_triggers,
              "check_uptime": check_uptime,
              "dryrun": dryrun,
              "maintenance_reason": maintenance_reason,
              "ignore_global_stop_flag": ignore_global_stop_flag,
              "ignore_node_disabled": ignore_node_disabled,
+             "ignore_failed_checks": ignore_failed_checks,
              "check_holidays": check_holidays,
              "lazy_consul_checks": lazy_consul_checks}
+
+    check_consul_cluster(con, ignore_failed_checks)
 
     consul_lock = Lock(con, "service/rebootmgr/lock")
     try:

--- a/rebootmgr/main.py
+++ b/rebootmgr/main.py
@@ -269,14 +269,22 @@ def get_config(con, hostname) -> dict:
 
     try:
         if data and "Value" in data.keys() and data["Value"]:
-            data = json.loads(data["Value"].decode())
-            if isinstance(data, dict):
-                return data
+            config = json.loads(data["Value"].decode())
+            if isinstance(config, dict):
+                maybe_migrate_config(con, hostname, config)
+                return config
     except Exception:
         pass
 
     LOG.error("Configuration data missing or malformed.")
     return {}
+
+
+def maybe_migrate_config(con, hostname, config):
+    if 'disabled' in config and 'enabled' not in config:
+        config['enabled'] = not config['disabled']
+        del config['disabled']
+        put_config(con, hostname, config)
 
 
 def put_config(con, hostname, config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,7 +130,7 @@ def reboot_task(mocker, mock_subprocess_run):
 def default_config(consul_cluster):
     hostname = socket.gethostname()
     key = "service/rebootmgr/nodes/%s/config" % hostname
-    consul_cluster[0].kv.put(key, '{"disabled": false}')
+    consul_cluster[0].kv.put(key, '{"enabled": true}')
 
 
 @pytest.fixture

--- a/tests/test_stopflag.py
+++ b/tests/test_stopflag.py
@@ -62,5 +62,5 @@ def test_set_local_stop_flag(
         hostname))
     assert idx is not None
     config = json.loads(data["Value"].decode())
-    assert config['disabled'] is True
+    assert config['enabled'] is False
     assert result.exit_code == 0

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -15,7 +15,7 @@ def test_reboot_task_timeout(run_cli, consul_cluster, forward_consul_port, defau
 
     _, data = consul_cluster[0].kv.get("service/rebootmgr/nodes/{}/config".format(socket.gethostname()))
     assert json.loads(data["Value"].decode()) == {
-        "disabled": True,
+        "enabled": False,
         "message": "Could not finish task /etc/rebootmgr/pre_boot_tasks/00_some_task.sh in 2 hours"
     }
     # TODO(oseibert): check that shutdown is NOT called.
@@ -32,13 +32,13 @@ def test_reboot_preboot_task_fails(run_cli, consul_cluster, forward_consul_port,
 
     _, data = consul_cluster[0].kv.get("service/rebootmgr/nodes/{}/config".format(socket.gethostname()))
     assert json.loads(data["Value"].decode()) == {
-        "disabled": False,
+        "enabled": True,
     }
     # TODO(oseibert): check that shutdown is NOT called.
 
 
 def test_reboot_task_timeout_with_preexisting_config(run_cli, consul_cluster, forward_consul_port, reboot_task, mocker):
-    consul_cluster[0].kv.put("service/rebootmgr/nodes/{}/config".format(socket.gethostname()), '{"disabled": false, "test_preserved": true}')
+    consul_cluster[0].kv.put("service/rebootmgr/nodes/{}/config".format(socket.gethostname()), '{"enabled": true, "test_preserved": true}')
     mocker.patch("time.sleep")
     reboot_task("pre_boot", "00_some_task.sh", raise_timeout_expired=True)
 
@@ -50,7 +50,7 @@ def test_reboot_task_timeout_with_preexisting_config(run_cli, consul_cluster, fo
     _, data = consul_cluster[0].kv.get("service/rebootmgr/nodes/{}/config".format(socket.gethostname()))
     assert json.loads(data["Value"].decode()) == {
         "test_preserved": True,
-        "disabled": True,
+        "enabled": False,
         "message": "Could not finish task /etc/rebootmgr/pre_boot_tasks/00_some_task.sh in 2 hours"
     }
     # TODO(oseibert): check that shutdown is NOT called.
@@ -69,6 +69,6 @@ def test_post_reboot_phase_task_timeout(run_cli, consul_cluster, forward_consul_
 
     _, data = consul_cluster[0].kv.get("service/rebootmgr/nodes/{}/config".format(socket.gethostname()))
     assert json.loads(data["Value"].decode()) == {
-        "disabled": True,
+        "enabled": False,
         "message": "Could not finish task /etc/rebootmgr/post_boot_tasks/50_another_task.sh in 2 hours"
     }

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -125,7 +125,7 @@ def test_reboot_on_not_a_holiday(
 def test_reboot_when_node_disabled(
         run_cli, forward_consul_port, consul_cluster, reboot_task,
         mock_subprocess_run, mocker):
-    consul_cluster[0].kv.put("service/rebootmgr/nodes/{}/config".format(socket.gethostname()), '{"disabled": true}')
+    consul_cluster[0].kv.put("service/rebootmgr/nodes/{}/config".format(socket.gethostname()), '{"enabled": false}')
 
     mocker.patch("time.sleep")
     mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
@@ -140,7 +140,7 @@ def test_reboot_when_node_disabled(
 def test_reboot_when_node_disabled_but_ignored(
         run_cli, forward_consul_port, consul_cluster, reboot_task,
         mock_subprocess_run, mocker):
-    consul_cluster[0].kv.put("service/rebootmgr/nodes/{}/config".format(socket.gethostname()), '{"disabled": true}')
+    consul_cluster[0].kv.put("service/rebootmgr/nodes/{}/config".format(socket.gethostname()), '{"enabled": false}')
 
     mocked_sleep = mocker.patch("time.sleep")
     mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
@@ -161,7 +161,7 @@ def test_reboot_when_node_disabled_after_sleep(
         reboot_task, mock_subprocess_run, mocker):
     def set_configuration_disabled(seconds):
         if seconds == 130:
-            consul_cluster[0].kv.put("service/rebootmgr/nodes/{}/config".format(socket.gethostname()), '{"disabled": true}')
+            consul_cluster[0].kv.put("service/rebootmgr/nodes/{}/config".format(socket.gethostname()), '{"enabled": false}')
 
     # When rebootmgr sleeps for 2 minutes, the stop flag will be set.
     mocked_sleep = mocker.patch("time.sleep", side_effect=set_configuration_disabled)

--- a/tests/test_whitelist.py
+++ b/tests/test_whitelist.py
@@ -4,7 +4,7 @@ from rebootmgr.main import cli as rebootmgr
 from consul import Check
 
 
-def test_reboot_succeeds_with_failed_checks_if_whitelisted(
+def test_reboot_succeeds_with_failing_checks_if_whitelisted(
         run_cli, consul_cluster, forward_consul_port, default_config,
         reboot_task, mock_subprocess_run, mocker):
     consul_cluster[0].kv.put("service/rebootmgr/ignore_failed_checks", '["consul2"]')
@@ -20,6 +20,23 @@ def test_reboot_succeeds_with_failed_checks_if_whitelisted(
     result = run_cli(rebootmgr, ["-v"])
 
     assert result.exit_code == 0
+
+
+def test_reboot_succeeds_with_failing_checks_if_ignored(
+        run_cli, consul_cluster, forward_consul_port, default_config,
+        reboot_task, mock_subprocess_run, mocker):
+    consul_cluster[0].agent.service.register("A", tags=["rebootmgr"])
+    consul_cluster[1].agent.service.register("A", tags=["rebootmgr"],
+                                             check=Check.ttl("1ms"))  # Failing
+    time.sleep(0.01)
+
+    mocker.patch("time.sleep")
+    mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
+
+    result = run_cli(rebootmgr, ["-v", "--ignore-failed-checks"])
+
+    assert result.exit_code == 0
+    assert mocked_run.call_count == 1
 
 
 def test_reboot_fails_with_failing_checks(
@@ -75,6 +92,27 @@ def test_reboot_succeeds_with_failing_consul_cluster_if_whitelisted(
     result = run_cli(rebootmgr, ["-v"])
 
     assert result.exit_code == 0
+
+
+def test_reboot_succeeds_with_failing_consul_cluster_if_ignored(
+        run_cli, consul_cluster, forward_consul_port, default_config,
+        reboot_task, mock_subprocess_run, mocker):
+    mocker.patch("time.sleep")
+    mocked_run = mock_subprocess_run(["shutdown", "-r", "+1"])
+
+    def newmembers(self):
+        return [
+            {'Status': 1, 'Name': 'consul1'},
+            {'Status': 0, 'Name': 'consul2'},
+        ]
+
+    mocker.patch("consul.base.Consul.Agent.members", new=newmembers)
+
+    result = run_cli(rebootmgr, ["-v", "--ignore-failed-checks"])
+
+    assert result.exit_code == 0
+    assert mocked_run.call_count == 1
+
 
 # TODO(oseibert): Test cases where consul service checks succeed/fail after the
 #  (2 * 60) + 10 seconds sleeping time, when they are done the second time.

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@ envlist = lint, py35, py36, py37, safety
 [testenv]
 deps =
     coverage
-    pytest
+    pytest==5.3.3 # Error in 5.3.4: https://github.com/pytest-dev/pytest/issues/6517
     pytest-mock
     -rrequirements.txt
 commands =
-    coverage run -m pytest --color=yes --maxfail 1 {posargs} tests/
+    coverage run -m pytest -v --color=yes --maxfail 1 {posargs} tests/
     coverage report
 
 [testenv:dev]


### PR DESCRIPTION
Use "enabled" instead of "disabled" in the configuration. That makes more sense and is consistent with other tools.

Current configuration settings are automatically migrated to the new style.