### PR TITLE
Separate consul tags

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -63,7 +63,8 @@ For an overview of how to register services and checks in consul, please refer t
 ### Relevant services
 
 - If service X is registered to the agent that is being rebooted, health of all instances of service X in the whole cluster (also on other nodes) are taken into consideration.
-- Only services with the tag `rebootmgr` will be taken into consideration.
+- Only services with the tags`rebootmgr`, `rebootmgr_postboot` and `rebootmgr_preboot` will be taken into consideration.
+- Services tagged with `rebootmgr` are considered before and after the reboot, `rebootmgr_preboot` only before  and `rebootmgr_postboot` only after a reboot.
 - Rebootmgr will consider services with consul maintenance mode enabled as broken, unless the service is tagged with `ignore_maintenance`
 - Rebootmgr assumes that `check_interval + check_timeout < 2 minutes`
 

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -154,6 +154,7 @@ def test_reboot_when_node_disabled_but_ignored(
 
 # TODO(oseibert): Should a MISSING configuration also be ignored with --ignore-node-disabled?
 
+
 # TODO(oseibert): Fix this bug.
 @pytest.mark.xfail
 def test_reboot_when_node_disabled_after_sleep(


### PR DESCRIPTION
Add two consul tags that are considered in the consul service checks. Services tagged with `rebootmgr_postboot` are only checked after reboot and services with the tag `rebootmgr_preboot` before. This makes it possible to have different checks before and after a reboot. 