### PR TITLE
Don't disable the node if a task runs into a timeout

### DIFF
--- a/rebootmgr/main.py
+++ b/rebootmgr/main.py
@@ -77,11 +77,6 @@ def run_tasks(tasktype, con, hostname, dryrun, task_timeout):
             sys.exit(EXIT_TASK_FAILED)
         except subprocess.TimeoutExpired:
             LOG.error("Could not finish task %s in %i minutes. Exit" % (task, task_timeout))
-            LOG.error("Disable rebootmgr in consul for this node")
-            data = get_config(con, hostname)
-            data["enabled"] = False
-            data["message"] = "Could not finish task %s in %i minutes" % (task, task_timeout)
-            put_config(con, hostname, data)
             con.kv.delete("service/rebootmgr/reboot_in_progress")
             sys.exit(EXIT_TASK_FAILED)
         LOG.info("task %s finished" % task)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -32,25 +32,6 @@ def test_reboot_preboot_task_fails(run_cli, consul_cluster, forward_consul_port,
     # TODO(oseibert): check that shutdown is NOT called.
 
 
-def test_reboot_task_timeout_with_preexisting_config(run_cli, consul_cluster, forward_consul_port, reboot_task, mocker):
-    consul_cluster[0].kv.put("service/rebootmgr/nodes/{}/config".format(socket.gethostname()), '{"enabled": true, "test_preserved": true}')
-    mocker.patch("time.sleep")
-    reboot_task("pre_boot", "00_some_task.sh", raise_timeout_expired=True)
-
-    result = run_cli(rebootmgr)
-
-    assert "Could not finish task /etc/rebootmgr/pre_boot_tasks/00_some_task.sh in 120 minutes" in result.output
-    assert result.exit_code == 100
-
-    _, data = consul_cluster[0].kv.get("service/rebootmgr/nodes/{}/config".format(socket.gethostname()))
-    assert json.loads(data["Value"].decode()) == {
-        "test_preserved": True,
-        "enabled": False,
-        "message": "Could not finish task /etc/rebootmgr/pre_boot_tasks/00_some_task.sh in 120 minutes"
-    }
-    # TODO(oseibert): check that shutdown is NOT called.
-
-
 def test_post_reboot_phase_task_timeout(run_cli, consul_cluster, forward_consul_port, default_config, reboot_task, mocker):
     reboot_task("post_boot", "50_another_task.sh", raise_timeout_expired=True)
 


### PR DESCRIPTION
There is no reason to treat timeout differently than other errors.