### PR TITLE
Applied recommended workaround for CVE-2023-32681

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,0 +1,5 @@
+security:
+    ignore-vulnerabilities:
+        58755:
+            reason: we implemented the recommended workaround
+            expires: '2024-07-01'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def consul_cluster(mocker):
         time.sleep(.1)
 
     snapshot_url = 'http://consul1:8500/v1/snapshot'
-    snapshot = requests.get(snapshot_url)
+    snapshot = requests.get(snapshot_url, allow_redirects=False)
     snapshot.raise_for_status()
 
     # Pretend we are the same host as clients[0]


### PR DESCRIPTION
Using this workaround, we don't need to update requests, making things easier as newer versions of requests don't support Python 3.6 anymore.

See https://github.com/psf/requests/security/advisories/GHSA-j8r2-6x86-q33q