### PR TITLE
Added ability to ignore checks in late pre reboot

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,5 +1,0 @@
-security:
-    ignore-vulnerabilities:
-        58755:
-            reason: we implemented the recommended workaround
-            expires: '2024-07-01'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,17 @@ services:
     depends_on: [consul1, consul2, consul3, consul4]
     command:
       ["tox", "-e", "py39"]
+  shell:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        PYTHON_VERSION: 3.9
+    volumes:
+      - .:/src
+    depends_on: [consul1, consul2, consul3, consul4]
+    command:
+      ["/bin/bash"]
   lint:
     build:
       context: .

--- a/rebootmgr/main.py
+++ b/rebootmgr/main.py
@@ -10,6 +10,7 @@ import time
 import colorlog
 import holidays
 import datetime
+from pathlib import Path
 from typing import List
 from typing import Tuple
 
@@ -37,6 +38,9 @@ EXIT_NODE_DISABLED = 101
 EXIT_STOP_FLAG_SET = 102
 EXIT_DID_NOT_REALLY_REBOOT = 103
 EXIT_CONFIGURATION_IS_MISSING = 104
+
+
+IGNORE_LOCAL_CHECKS_PATH = "/var/run/rebootmgr-ignore-local-checks"
 
 
 def logsetup(verbosity):
@@ -126,7 +130,7 @@ def get_whitelist(con) -> List[str]:
     return []
 
 
-def check_consul_services(con, hostname, ignore_failed_checks: bool, tags: List[str], wait_until_healthy=False):
+def check_consul_services(con, hostname, ignore_failed_checks: bool, tags: List[str], wait_until_healthy=False, ignore_local_checks: List[str] = []):
     """
     check all consul services for this node with the tag "rebootmgr"
     """
@@ -152,6 +156,8 @@ def check_consul_services(con, hostname, ignore_failed_checks: bool, tags: List[
                 # is-in-maintenance-mode check, ignore it.
                 if name == '_node_maintenance' and check["Node"] == hostname:
                     pass
+                elif name in ignore_local_checks and check["Node"] == hostname:
+                    pass
                 else:
                     failed_names.append(name + " on " + check["Node"])
 
@@ -159,7 +165,7 @@ def check_consul_services(con, hostname, ignore_failed_checks: bool, tags: List[
             if wait_until_healthy:
                 LOG.error("There were failed consul checks (%s). Trying again in 2 minutes.", failed_names)
                 time.sleep(120)
-                check_consul_services(con, hostname, ignore_failed_checks, tags, wait_until_healthy)
+                check_consul_services(con, hostname, ignore_failed_checks, tags, wait_until_healthy, ignore_local_checks)
             else:
                 LOG.error("There were failed consul checks (%s). Exit.", failed_names)
                 sys.exit(EXIT_CONSUL_CHECKS_FAILED)
@@ -409,6 +415,25 @@ def _check_and_handle_stop_flag(con, group, hostname, flags):
         sys.exit(EXIT_STOP_FLAG_SET)
 
 
+def _remove_ignore_local_checks_file():
+    ignore_local_checks_path = Path(IGNORE_LOCAL_CHECKS_PATH)
+    if ignore_local_checks_path.is_file() and ignore_local_checks_path.stat().st_size > 0:
+        LOG.info("Deleting %s file" % IGNORE_LOCAL_CHECKS_PATH)
+        ignore_local_checks_path.unlink()
+
+
+def _get_ignore_local_checks():
+    ignore_local_checks = []
+    ignore_local_checks_path = Path(IGNORE_LOCAL_CHECKS_PATH)
+    if ignore_local_checks_path.is_file() and ignore_local_checks_path.stat().st_size > 0:
+        LOG.info("Parsing %s file" % IGNORE_LOCAL_CHECKS_PATH)
+        with ignore_local_checks_path.open("r") as ignore_local_checks_file:
+            for line in ignore_local_checks_file:
+                ignore_local_checks.append("service:" + line)
+    LOG.info(f"ignore_local_checks = {ignore_local_checks}")
+    return ignore_local_checks
+
+
 def pre_reboot_state(con, consul_lock, hostname, flags, task_timeout, group):
     group_key = resolve_group_key(con, group, hostname)
     today = datetime.date.today()
@@ -430,6 +455,7 @@ def pre_reboot_state(con, consul_lock, hostname, flags, task_timeout, group):
     check_consul_services(con, hostname, flags.get("ignore_failed_checks"), ["rebootmgr", "rebootmgr_preboot"])
 
     LOG.info("Executing pre reboot tasks")
+    _remove_ignore_local_checks_file()
     run_tasks("pre_boot", con, hostname, flags.get("dryrun"), task_timeout, group)
 
     if not flags.get("lazy_consul_checks"):
@@ -437,7 +463,11 @@ def pre_reboot_state(con, consul_lock, hostname, flags, task_timeout, group):
         time.sleep((60 * 2) + 10)
 
     check_consul_cluster(con, hostname, flags.get("ignore_failed_checks"))
-    check_consul_services(con, hostname, flags.get("ignore_failed_checks"), ["rebootmgr", "rebootmgr_preboot"])
+
+    # Pre reboot scripts may write into /var/run/rebootmgr-ignore-local-checks
+    # the names of the checks that are expected to fail at this stage
+    ignore_local_checks = _get_ignore_local_checks()
+    check_consul_services(con, hostname, flags.get("ignore_failed_checks"), ["rebootmgr", "rebootmgr_preboot"], ignore_local_checks=ignore_local_checks)
 
     if not consul_lock.acquired:
         LOG.error("Lost consul lock. Exit")

--- a/tests/test_whitelist.py
+++ b/tests/test_whitelist.py
@@ -3,6 +3,9 @@ import time
 from rebootmgr.main import cli as rebootmgr
 from consul import Check
 
+from pathlib import Path
+from types import SimpleNamespace
+
 
 def test_reboot_succeeds_with_failing_checks_if_whitelisted(
         run_cli, consul_cluster, forward_consul_port, default_config,
@@ -39,6 +42,70 @@ def test_reboot_succeeds_with_failing_checks_if_ignored(
 
     assert result.exit_code == 0
     assert mocked_run.call_count == 1
+
+
+def test_reboot_succeeds_with_failing_checks_if_local_ignored(
+        run_cli, consul_cluster, forward_consul_port, default_config,
+        reboot_task, mock_subprocess_run, mocker):
+    consul_cluster[0].agent.service.register("A", tags=["rebootmgr"])
+    consul_cluster[1].agent.service.register("A", tags=["rebootmgr"])
+
+    mocker.patch("time.sleep")
+    mocker.patch("subprocess.Popen")
+    mock_subprocess_run(["shutdown", "-r", "+1"])
+
+    def break_consul_service():
+        """ Break consul service A on localhost as soon as "open" is called. """
+        consul_cluster[0].agent.service.deregister("A")
+        consul_cluster[0].agent.service.register("A", tags=["rebootmgr"], check=Check.ttl("1ms"))
+        time.sleep(0.01)
+
+    opener = mocker.mock_open(read_data='A')
+    opener.return_value.__iter__.return_value = iter(['A'])  # workaround Python 3.6 specific bug
+
+    def mocked_open(self, *args, **kwargs):
+        break_consul_service()
+        return opener(self, *args, **kwargs)
+
+    mocker.patch.object(Path, "unlink")
+    mocker.patch.object(Path, "is_file", return_value=True)
+    mocker.patch.object(Path, "stat", return_value=SimpleNamespace(st_size=1))
+    mocker.patch.object(Path, "open", mocked_open)
+    result = run_cli(rebootmgr, ["-v"])
+
+    assert result.exit_code == 0
+
+
+def test_reboot_fails_with_remote_failing_checks_if_local_ignored(
+        run_cli, consul_cluster, forward_consul_port, default_config,
+        reboot_task, mock_subprocess_run, mocker):
+    consul_cluster[0].agent.service.register("A", tags=["rebootmgr"])
+    consul_cluster[1].agent.service.register("A", tags=["rebootmgr"])
+
+    mocker.patch("time.sleep")
+    mocker.patch("subprocess.Popen")
+    mock_subprocess_run(["shutdown", "-r", "+1"])
+
+    def break_consul_service():
+        """ Break consul service A on the other node as soon as "open" is called. """
+        consul_cluster[1].agent.service.deregister("A")
+        consul_cluster[1].agent.service.register("A", tags=["rebootmgr"], check=Check.ttl("1ms"))
+        time.sleep(0.01)
+
+    opener = mocker.mock_open(read_data='A')
+    opener.return_value.__iter__.return_value = iter(['A'])  # workaround Python 3.6 specific bug
+
+    def mocked_open(self, *args, **kwargs):
+        break_consul_service()
+        return opener(self, *args, **kwargs)
+
+    mocker.patch.object(Path, "unlink")
+    mocker.patch.object(Path, "is_file", return_value=True)
+    mocker.patch.object(Path, "stat", return_value=SimpleNamespace(st_size=1))
+    mocker.patch.object(Path, "open", mocked_open)
+    result = run_cli(rebootmgr, ["-v"])
+
+    assert result.exit_code == 2
 
 
 def test_reboot_fails_with_failing_checks(
@@ -118,7 +185,3 @@ def test_reboot_succeeds_with_failing_consul_cluster_if_ignored(
 
     assert result.exit_code == 0
     assert mocked_run.call_count == 1
-
-
-# TODO(oseibert): Test cases where consul service checks succeed/fail after the
-#  (2 * 60) + 10 seconds sleeping time, when they are done the second time.

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ usedevelop = True
 deps =
     safety
     -rrequirements.txt
-commands = safety check {posargs} --full-report --ignore=71064,58755,77680,61601,71608,61893,77744,84031,82332,82331
+commands = safety check {posargs} --full-report --ignore=71064,58755,77680,61601,71608,61893,77744,84031,82332,82331,90553
 usedevelop = True
 
 


### PR DESCRIPTION
Pre reboot scripts can write Consul check names in `/var/run/rebootmgr-ignore-local-checks` that are expected to fail after the scripts ran. Rebootmgr will ignore such failed checks in the final Consul checks done just before reboot.

See os-24482